### PR TITLE
Improved packing logic

### DIFF
--- a/src/maxrects-bin.ts
+++ b/src/maxrects-bin.ts
@@ -161,7 +161,7 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         for (let i in this.freeRects) {
             r = this.freeRects[i];
             if (r.width >= width && r.height >= height) {
-                areaFit = r.width * r.height - width * height;
+                areaFit = Math.min(r.width - width, r.height - height);
                 if (areaFit < score) {
                     bestNode = new Rectangle(width, height, r.x, r.y);
                     score = areaFit;
@@ -170,7 +170,7 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
             if (!this.options.allowRotation) continue;
             // Continue to test 90-degree rotated rectangle
             if (r.width >= height && r.height >= width) {
-                areaFit = r.width * r.height - height * width;
+                areaFit = Math.min(r.height - width, r.width - height);
                 if (areaFit < score) {
                     bestNode = new Rectangle(height, width, r.x, r.y, true); // Rotated node
                     score = areaFit;

--- a/src/maxrects-packer.ts
+++ b/src/maxrects-packer.ts
@@ -222,7 +222,7 @@ export class MaxRectsPacker<T extends IRectangle = Rectangle> {
     }
 
     /**
-     * Sort the given rects based on longest edge
+     * Sort the given rects based on surface area
      *
      * If having same long edge, will sort second key `hash` if presented.
      *
@@ -233,7 +233,7 @@ export class MaxRectsPacker<T extends IRectangle = Rectangle> {
      */
     private sort (rects: T[]) {
         return rects.slice().sort((a, b) => {
-            const result = Math.max(b.width, b.height) - Math.max(a.width, a.height);
+            const result = b.width * b.height - a.width * a.height;
             if (result === 0 && a.hash && b.hash) {
                 return a.hash > b.hash ? -1 : 1;
             } else return result;

--- a/test/efficiency.spec.js
+++ b/test/efficiency.spec.js
@@ -30,7 +30,8 @@ test('Efficiency', () => {
     }).concat([["sum", ""].concat(results.map(result => {
         let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
         let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
-        return toPercent(rectSize / usedSize);
+        let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
+        return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
     }))]);
 
     console.log(new AsciiTable({ heading, rows }).toString());

--- a/test/maxrects-packer.spec.js
+++ b/test/maxrects-packer.spec.js
@@ -110,8 +110,8 @@ describe("#sort", () => {
             {width: 2, height: 2}
         ];
         let output = packer.sort(input);
-        expect(output[0].width).toBe(3);
-        expect(output[1].width).toBe(2);
+        expect(output[0].width).toBe(2);
+        expect(output[1].width).toBe(3);
         expect(output[2].width).toBe(1);
     });
 });


### PR DESCRIPTION
# Description
We recently started using Free Texture Packer (http://free-tex-packer.com/) which has an option to pack the rectangles using this package. We weren't happy with the original results so we started looking into what's going on.

One thing we noticed that it wasn't properly passing the rotation parameter to the MaxRectsPacker which is now fixed in a pull request here: https://github.com/odrick/free-tex-packer-core/pull/6

Once we got the rotation working we got better results straight away but still we were not happy. Digging deeper into the MaxRectsPacker algorithm showed that at least in our particular use case it could be more optimal. So we did 2 modifications to the algorithm: 1) Sort rectangles by their surface area to "get rid" of the largest images first since they're always difficult to insert later. 2) Use "closest edge fit" check in selecting the node - so giving a better score for bins where either dimension is a close match to the rectangle. This is especially useful with the rotate option.

# Real life test case:

**Before changes - no rotation:**
![before-norotate](https://user-images.githubusercontent.com/752359/63652278-2fdbbe80-c767-11e9-965a-6bc93d4dfdb1.png)

Total of 12 sheets.

**After changes - no rotation:**
![after-norotate](https://user-images.githubusercontent.com/752359/63652293-5568c800-c767-11e9-8130-4036ec718a4d.png)

Total of 12 sheets = no change.

**Before changes - with rotation:**
![before-rotate](https://user-images.githubusercontent.com/752359/63652305-91039200-c767-11e9-9a8e-5eb63374c91c.png)

Total of 11 sheets.

**After changes - with rotation:**
![after-rotate](https://user-images.githubusercontent.com/752359/63652310-a678bc00-c767-11e9-9464-15740054e368.png)

Total of 9 sheets = improvement of 2 sheets.

# Efficiency tests
Running the efficiency tests from the package show some overall improvement for the sums:
```
Before:
| 83.0% (292 bins) | 83.0% (292 bins) | 79.3% (431 bins)   | 78.7% (432 bins) | 78.4% (434 bins) | 78.3% (431 bins) | 74.1% (113 bins) | 69.5% (113 bins) |
After:
| 83.3% (292 bins) | 83.1% (292 bins) | 80.1% (428 bins)   | 78.7% (432 bins) | 78.6% (434 bins) | 79.1% (428 bins) | 74.1% (114 bins) | 70.8% (113 bins) |
Change:
| +0.3%   (0 bins) | +0.1%   (0 bins) | +0.8%  (-3 bins)   |  0.0%   (0 bins) | +0.2%   (0 bins) | +0.8%  (-3 bins) |  0.0%  (+1 bins) | +1.3%   (0 bins) |
```

# Summary
Even though this change does show some overall improvement there are some scenarios where the old one generates less bins. So my question to @soimy is basically this: Should this change be either A) accepted as the new standard, B) made into an user option or C) testing both methods and choosing the best one?

ps. With this change the results for our test case (number of sheets) are consistent with the "famous Texture Packer" that is mentioned in the readme. Before it was not, which is one of the reasons why we started looking into this.