### PR TITLE
Optional "area" or "edge" logic

### DIFF
--- a/src/maxrects-bin.ts
+++ b/src/maxrects-bin.ts
@@ -15,7 +15,7 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         public maxWidth: number = EDGE_MAX_VALUE,
         public maxHeight: number = EDGE_MAX_VALUE,
         public padding: number = 0,
-        public options: IOption = { smart: true, pot: true, square: true, allowRotation: false, tag: false, border: 0 }
+        public options: IOption = { smart: true, pot: true, square: true, allowRotation: false, tag: false, border: 0, logic: 'area' }
     ) {
         super();
         this.width = this.options.smart ? 0 : maxWidth;
@@ -161,7 +161,9 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         for (let i in this.freeRects) {
             r = this.freeRects[i];
             if (r.width >= width && r.height >= height) {
-                areaFit = Math.min(r.width - width, r.height - height);
+                areaFit = (this.options.logic === 'edge') ?
+                    r.width * r.height - width * height :
+                    Math.min(r.width - width, r.height - height);
                 if (areaFit < score) {
                     bestNode = new Rectangle(width, height, r.x, r.y);
                     score = areaFit;
@@ -170,7 +172,9 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
             if (!this.options.allowRotation) continue;
             // Continue to test 90-degree rotated rectangle
             if (r.width >= height && r.height >= width) {
-                areaFit = Math.min(r.height - width, r.width - height);
+                areaFit = (this.options.logic === 'edge') ?
+                    r.width * r.height - height * width :
+                    Math.min(r.height - width, r.width - height);
                 if (areaFit < score) {
                     bestNode = new Rectangle(height, width, r.x, r.y, true); // Rotated node
                     score = areaFit;

--- a/test/efficiency.spec.js
+++ b/test/efficiency.spec.js
@@ -9,8 +9,8 @@ let rectSizeSum = SCENARIOS.map(scenario => {
     return scenario.reduce((memo, rect) => memo + rect.width * rect.height, 0);
 });
 
-test('Efficiency', () => {
-    const CANDIDATES = [
+describe('Efficiency', () => {
+    const AREA_CANDIDATES = [
         {name: "1024x2048:0", factory: () => new MaxRectsPacker(1024, 2048, 0)},
         {name: "1024x2048:1", factory: () => new MaxRectsPacker(1024, 2048, 1)},
         {name: "1024x2048:1:Rot", factory: () => new MaxRectsPacker(1024, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true})},
@@ -20,22 +20,86 @@ test('Efficiency', () => {
         {name: "2048:2048:1", factory: () => new MaxRectsPacker(2048, 2048, 1)},
         {name: "2048:2048:1:Rot", factory: () => new MaxRectsPacker(2048, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true})}
     ];
-    let heading = ["#", "size"].concat(CANDIDATES.map(c => c.name));
-    let results = CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
-    let rows = SCENARIOS.map((scenario, i) => {
-        return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
-            let result = resultCandidate[i];
-            return `${toPercent(result.efficieny)} (${result.bins} bins)`;
+
+    const EDGE_CANDIDATES = [
+        {name: "1024x2048:0", factory: () => new MaxRectsPacker(1024, 2048, 0, { smart: true, pot: true, square: false, logic: "edge" })},
+        {name: "1024x2048:1", factory: () => new MaxRectsPacker(1024, 2048, 1, { smart: true, pot: true, square: false, logic: "edge" })},
+        {name: "1024x2048:1:Rot", factory: () => new MaxRectsPacker(1024, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true, logic: "edge" })},
+        {name: "1024x1024:0", factory: () => new MaxRectsPacker(1024, 1024, 0, { smart: true, pot: true, square: false, logic: "edge" })},
+        {name: "1024x1024:1", factory: () => new MaxRectsPacker(1024, 1024, 1, { smart: true, pot: true, square: false, logic: "edge" })},
+        {name: "1024x1024:1:Rot", factory: () => new MaxRectsPacker(1024, 1024, 1, { smart: true, pot: true, square: true, allowRotation: true, logic: "edge" })},
+        {name: "2048:2048:1", factory: () => new MaxRectsPacker(2048, 2048, 1, { smart: true, pot: true, square: false, logic: "edge" })},
+        {name: "2048:2048:1:Rot", factory: () => new MaxRectsPacker(2048, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true, logic: "edge" })}
+    ];
+
+    test.skip('area logic', () => {
+        let heading = ["#", "size"].concat(AREA_CANDIDATES.map(c => c.name));
+        let results = AREA_CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
+        let rows = SCENARIOS.map((scenario, i) => {
+            return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
+                let result = resultCandidate[i];
+                return `${toPercent(result.efficieny)} (${result.bins} bins)`;
+            }));
+        }).concat([["sum", ""].concat(results.map(result => {
+            let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
+            let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
+            let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
+            return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
+        }))]);
+
+        console.log(new AsciiTable({ heading, rows }).toString());
+    });
+
+    test.skip('edge logic', () => {
+        let heading = ["#", "size"].concat(EDGE_CANDIDATES.map(c => c.name));
+        let results = EDGE_CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
+        let rows = SCENARIOS.map((scenario, i) => {
+            return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
+                let result = resultCandidate[i];
+                return `${toPercent(result.efficieny)} (${result.bins} bins)`;
+            }));
+        }).concat([["sum", ""].concat(results.map(result => {
+            let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
+            let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
+            let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
+            return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
+        }))]);
+
+        console.log(new AsciiTable({ heading, rows }).toString());
+    });
+
+    test('combined best of', () => {
+        let heading = ["#", "size"].concat(AREA_CANDIDATES.map(c => c.name));
+        let results1 = EDGE_CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
+        let results2 = AREA_CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
+        let results = results1.map((scenario, scenarioIndex) => scenario.map((result1, resultIndex) => {
+            const result2 = results2[scenarioIndex][resultIndex];
+            if (result1.bins < result2.bins) {
+                return result1;
+            } else if (result1.bins > result2.bins) {
+                return result2;
+            } else if (result1.efficieny > result2.efficieny) {
+                return result1;
+            } else if (result1.efficieny < result2.efficieny) {
+                return result2;
+            } else {
+                return result1;
+            }
         }));
-    }).concat([["sum", ""].concat(results.map(result => {
-        let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
-        let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
-        let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
-        return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
-    }))]);
+        let rows = SCENARIOS.map((scenario, i) => {
+            return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
+                let result = resultCandidate[i];
+                return `${toPercent(result.efficieny)} (${result.bins} bins)`;
+            }));
+        }).concat([["sum", ""].concat(results.map(result => {
+            let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
+            let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
+            let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
+            return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
+        }))]);
 
-    console.log(new AsciiTable({ heading, rows }).toString());
-
+        console.log(new AsciiTable({ heading, rows }).toString());
+    });
 });
 
 function meassureEfficiency (factory) {

--- a/test/efficiency.spec.js
+++ b/test/efficiency.spec.js
@@ -35,35 +35,15 @@ describe('Efficiency', () => {
     test.skip('area logic', () => {
         let heading = ["#", "size"].concat(AREA_CANDIDATES.map(c => c.name));
         let results = AREA_CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
-        let rows = SCENARIOS.map((scenario, i) => {
-            return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
-                let result = resultCandidate[i];
-                return `${toPercent(result.efficieny)} (${result.bins} bins)`;
-            }));
-        }).concat([["sum", ""].concat(results.map(result => {
-            let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
-            let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
-            let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
-            return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
-        }))]);
-
+        let rows = createRows(results);
+        
         console.log(new AsciiTable({ heading, rows }).toString());
     });
 
     test.skip('edge logic', () => {
         let heading = ["#", "size"].concat(EDGE_CANDIDATES.map(c => c.name));
         let results = EDGE_CANDIDATES.map(candidate => meassureEfficiency(candidate.factory));
-        let rows = SCENARIOS.map((scenario, i) => {
-            return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
-                let result = resultCandidate[i];
-                return `${toPercent(result.efficieny)} (${result.bins} bins)`;
-            }));
-        }).concat([["sum", ""].concat(results.map(result => {
-            let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
-            let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
-            let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
-            return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
-        }))]);
+        let rows = createRows(results);
 
         console.log(new AsciiTable({ heading, rows }).toString());
     });
@@ -86,17 +66,7 @@ describe('Efficiency', () => {
                 return result1;
             }
         }));
-        let rows = SCENARIOS.map((scenario, i) => {
-            return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
-                let result = resultCandidate[i];
-                return `${toPercent(result.efficieny)} (${result.bins} bins)`;
-            }));
-        }).concat([["sum", ""].concat(results.map(result => {
-            let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
-            let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
-            let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
-            return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
-        }))]);
+        let rows = createRows(results);
 
         console.log(new AsciiTable({ heading, rows }).toString());
     });
@@ -117,4 +87,18 @@ function meassureEfficiency (factory) {
 
 function toPercent (input) {
     return Math.round(input * 1000) / 10 + "%";
+}
+
+function createRows (results) {
+    return SCENARIOS.map((scenario, i) => {
+        return [i, rectSizeSum[i]].concat(results.map(resultCandidate => {
+            let result = resultCandidate[i];
+            return `${toPercent(result.efficieny)} (${result.bins} bins)`;
+        }));
+    }).concat([["sum", ""].concat(results.map(result => {
+        let usedSize = result.reduce((memo, data) => memo + data.usedSize, 0);
+        let rectSize = result.reduce((memo, data) => memo + data.rectSize, 0);
+        let totalBins = result.reduce((memo, data) => memo + data.bins, 0);
+        return `${toPercent(rectSize / usedSize)} (${totalBins} bins)`;
+    }))]);
 }

--- a/test/maxrects-packer.spec.js
+++ b/test/maxrects-packer.spec.js
@@ -103,15 +103,27 @@ describe("#sort", () => {
         expect(input[0].width).toBe(1);
     });
 
-    test("works correctly", () => {
+    test("works correctly by area", () => {
         let input = [
             {width: 1, height: 1},
             {width: 3, height: 1},
             {width: 2, height: 2}
         ];
-        let output = packer.sort(input);
+        let output = packer.sort(input, "area");
         expect(output[0].width).toBe(2);
         expect(output[1].width).toBe(3);
+        expect(output[2].width).toBe(1);
+    });
+
+    test("works correctly by edge", () => {
+        let input = [
+            {width: 1, height: 1},
+            {width: 3, height: 1},
+            {width: 2, height: 2}
+        ];
+        let output = packer.sort(input, "edge");
+        expect(output[0].width).toBe(3);
+        expect(output[1].width).toBe(2);
         expect(output[2].width).toBe(1);
     });
 });


### PR DESCRIPTION
After doing the previous pull request for the new "area" logic I couldn't shake the feeling that in some cases it was worse than before. So I decided to make it into an option after all.

The benefits of having this as an option as opposed to trying with both is that it keeps the code much more simple (and extendable). This allows the users of the package to choose the optimal method for them, or to implement a brute-force test that tries both versions and chooses the best - similar to the one proposed here for the free Texture Packer: https://github.com/odrick/free-tex-packer-core/issues/5

I added separate efficiency tests for both modes (which are skipped by default) and one that selects the best from both results (first by less bins and then by better efficiency) to demonstrate the efficiency gains by doing this.

```
Edge logic (the original one):
| 83.0% (292 bins) | 83.0% (292 bins) | 79.3% (431 bins)   | 78.7% (432 bins) | 78.4% (434 bins) | 78.3% (431 bins) | 74.1% (113 bins) | 69.5% (113 bins) |

Area logic (the new one):
| 83.3% (292 bins) | 83.1% (292 bins) | 80.1% (428 bins)   | 78.7% (432 bins) | 78.6% (434 bins) | 79.1% (428 bins) | 74.1% (114 bins) | 70.8% (113 bins) |

Combined best of:
| 83.3% (292 bins) | 83.1% (292 bins) | 80.2% (427 bins)   | 79.2% (431 bins) | 78.8% (433 bins) | 79.1% (427 bins) | 74.7% (113 bins) | 70.8% (112 bins) |
```

As can be seen the combined method is able to even further reduce the bin count which I believe is worth the added complexity.