### PR TITLE
Fixes to default packing logic usage and documentation

### DIFF
--- a/src/maxrects-bin.ts
+++ b/src/maxrects-bin.ts
@@ -15,7 +15,7 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         public maxWidth: number = EDGE_MAX_VALUE,
         public maxHeight: number = EDGE_MAX_VALUE,
         public padding: number = 0,
-        public options: IOption = { smart: true, pot: true, square: true, allowRotation: false, tag: false, border: 0, logic: PACKING_LOGIC.MAX_AREA }
+        public options: IOption = { smart: true, pot: true, square: true, allowRotation: false, tag: false, border: 0, logic: PACKING_LOGIC.MAX_EDGE }
     ) {
         super();
         this.width = this.options.smart ? 0 : maxWidth;

--- a/src/maxrects-packer.ts
+++ b/src/maxrects-packer.ts
@@ -18,7 +18,7 @@ export enum PACKING_LOGIC {
  * @property {boolean} options.allowRotation allow rotation packing (default is false)
  * @property {boolean} options.tag allow auto grouping based on `rect.tag` (default is false)
  * @property {boolean} options.border atlas edge spacing (default is 0)
- * @property {string} options.logic "area" or "edge" based sorting logic (default is "area")
+ * @property {PACKING_LOGIC} options.logic MAX_AREA or MAX_EDGE based sorting logic (default is MAX_EDGE)
  * @export
  * @interface Option
  */
@@ -29,7 +29,7 @@ export interface IOption {
     allowRotation?: boolean;
     tag?: boolean;
     border?: number;
-    logic?: PACKING_LOGIC.MAX_AREA | PACKING_LOGIC.MAX_EDGE;
+    logic?: PACKING_LOGIC;
 }
 
 export class MaxRectsPacker<T extends IRectangle = Rectangle> {
@@ -234,7 +234,7 @@ export class MaxRectsPacker<T extends IRectangle = Rectangle> {
      *
      * @private
      * @param {T[]} rects
-     * @param {string} [logic="area"] sorting logic, "area" or "edge"
+     * @param {PACKING_LOGIC} [logic=PACKING_LOGIC.MAX_EDGE] sorting logic, "area" or "edge"
      * @returns
      * @memberof MaxRectsPacker
      */

--- a/test/efficiency.spec.js
+++ b/test/efficiency.spec.js
@@ -12,14 +12,14 @@ let rectSizeSum = SCENARIOS.map(scenario => {
 
 describe('Efficiency', () => {
     const AREA_CANDIDATES = [
-        {name: "1024x2048:0", factory: () => new MaxRectsPacker(1024, 2048, 0)},
-        {name: "1024x2048:1", factory: () => new MaxRectsPacker(1024, 2048, 1)},
-        {name: "1024x2048:1:Rot", factory: () => new MaxRectsPacker(1024, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true})},
-        {name: "1024x1024:0", factory: () => new MaxRectsPacker(1024, 1024, 0)},
-        {name: "1024x1024:1", factory: () => new MaxRectsPacker(1024, 1024, 1)},
-        {name: "1024x1024:1:Rot", factory: () => new MaxRectsPacker(1024, 1024, 1, { smart: true, pot: true, square: true, allowRotation: true})},
-        {name: "2048:2048:1", factory: () => new MaxRectsPacker(2048, 2048, 1)},
-        {name: "2048:2048:1:Rot", factory: () => new MaxRectsPacker(2048, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true})}
+        {name: "1024x2048:0", factory: () => new MaxRectsPacker(1024, 2048, 0, { smart: true, pot: true, square: false, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "1024x2048:1", factory: () => new MaxRectsPacker(1024, 2048, 1, { smart: true, pot: true, square: false, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "1024x2048:1:Rot", factory: () => new MaxRectsPacker(1024, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "1024x1024:0", factory: () => new MaxRectsPacker(1024, 1024, 0, { smart: true, pot: true, square: false, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "1024x1024:1", factory: () => new MaxRectsPacker(1024, 1024, 1, { smart: true, pot: true, square: false, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "1024x1024:1:Rot", factory: () => new MaxRectsPacker(1024, 1024, 1, { smart: true, pot: true, square: true, allowRotation: true, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "2048:2048:1", factory: () => new MaxRectsPacker(2048, 2048, 1, { smart: true, pot: true, square: false, logic: PACKING_LOGIC.MAX_AREA })},
+        {name: "2048:2048:1:Rot", factory: () => new MaxRectsPacker(2048, 2048, 1, { smart: true, pot: true, square: true, allowRotation: true, logic: PACKING_LOGIC.MAX_AREA })}
     ];
 
     const EDGE_CANDIDATES = [


### PR DESCRIPTION
I noticed that the JSDocs hadn't been updated to reflect the new default packing logic (EDGE) and the types in the JSDocs were not changed to the new enum type. Also related since the default is EDGE logic the efficiency test was using EDGE twice so I fixed that to also run with the two different logics.