### PR TITLE
51 expanding one dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Creates a new Packer. maxWidth and maxHeight are passed on to all bins. If ```pa
 - `options.tag` allow tag based group packing. (default is `false`)
 - `options.exclusiveTag` tagged rects will have dependent bin, if set to `false`, packer will try to put tag rects into the same bin (default is `true`)
 - `options.border` atlas edge spacing (default is 0)
+- `options.logic` how to fill the rects. There are three options: maxArea, maxEdge, fillWidth. Default is maxEdge
 
 #### ```packer.add(width, height, data)``` +1 overload
 
@@ -135,6 +136,18 @@ If `options.tag` is set to `true`, packer will check if the input object has `ta
 ## Support for oversized rectangles
 
 Normally all bins are of equal size or smaller than ```maxWidth```/```maxHeight```. If a rect is added that individually does not fit into those constraints a special bin will be created. This bin will only contain a single rect with a special "oversized" flag. This can be handled further on in the chain by displaying an error/warning or by simply ignoring it.
+
+## Packing logic
+
+`options.logic` allows to change the method on how the algorithm selects the free spaces. There are three options:
+
+`{option.logic = "maxEdge"}` is default and selects the free space with the smallest loss of either width or height.
+
+`{option.logic = "maxArea"}` selects the free space with the smallest loss of area.
+
+`{option.logic = "fillWidth"}` fills the complete width first before placing elements in next row. To get the used height `bin.height` only gives correct values with options: `{pot: false, square: false}`. Best results also with `option.allowRotation = true`
+
+
 
 ## Packing algorithm
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Creates a new Packer. maxWidth and maxHeight are passed on to all bins. If ```pa
 - `options.tag` allow tag based group packing. (default is `false`)
 - `options.exclusiveTag` tagged rects will have dependent bin, if set to `false`, packer will try to put tag rects into the same bin (default is `true`)
 - `options.border` atlas edge spacing (default is 0)
-- `options.logic` how to fill the rects. There are three options: maxArea, maxEdge, fillWidth. Default is maxEdge
+- `options.logic` how to fill the rects. There are three options: 0 (max area),  1 (max edge), 2 (fillWidth). Default is 1 (max edge)
 
 #### ```packer.add(width, height, data)``` +1 overload
 
@@ -141,11 +141,11 @@ Normally all bins are of equal size or smaller than ```maxWidth```/```maxHeight`
 
 `options.logic` allows to change the method on how the algorithm selects the free spaces. There are three options:
 
-`{option.logic = "maxEdge"}` is default and selects the free space with the smallest loss of either width or height.
+`{option.logic = 0}` Logic is MAX_AREA, selects the free space with the smallest loss of area.
 
-`{option.logic = "maxArea"}` selects the free space with the smallest loss of area.
+`{option.logic = 1}` Logic is MAX_EDGE, is default and selects the free space with the smallest loss of either width or height.
 
-`{option.logic = "fillWidth"}` fills the complete width first before placing elements in next row. To get the used height `bin.height` only gives correct values with options: `{pot: false, square: false}`. Best results also with `option.allowRotation = true`
+`{option.logic = 2}` Logic is FILL_WIDTH, fills the complete width first before placing elements in next row. To get the used height `bin.height` only gives correct values with options: `{pot: false, square: false}`. Best results also with `option.allowRotation = true`
 
 
 

--- a/src/maxrects-bin.ts
+++ b/src/maxrects-bin.ts
@@ -151,7 +151,7 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
                 i++;
             }
             this.pruneFreeList();
-            this.verticalExpand = this.width > this.height ? true : false;
+            this.verticalExpand = this.options.logic === PACKING_LOGIC.FILL_WIDTH ? false : this.width > this.height ? true : false;
             rect.x = node.x;
             rect.y = node.y;
             if (rect.rot === undefined) rect.rot = false;
@@ -339,9 +339,6 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         if (this.options.pot) {
             tmpWidth = Math.pow(2, Math.ceil(Math.log(tmpWidth) * Math.LOG2E));
             tmpHeight = Math.pow(2, Math.ceil(Math.log(tmpHeight) * Math.LOG2E));
-        }
-        if (this.options.logic === PACKING_LOGIC.FILL_WIDTH) {
-            tmpWidth = this.maxWidth;
         }
         if (this.options.square) {
             tmpWidth = tmpHeight = Math.max(tmpWidth, tmpHeight);

--- a/src/maxrects-bin.ts
+++ b/src/maxrects-bin.ts
@@ -182,7 +182,16 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         return undefined;
     }
 
+    /**
+     * Find the best rect out of freeRects
+     * This method has different logics to resolve the best rect.
+     * @param width 
+     * @param height 
+     * @param allowRotation 
+     * @returns Rectangle of the best rect for placement
+     */
     private findNode (width: number, height: number, allowRotation?: boolean): Rectangle | undefined {
+        // scoring based on one single number. The smaller the better the choice.
         let score: number = Number.MAX_VALUE;
         let areaFit: number;
         let r: Rectangle;
@@ -190,9 +199,25 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         for (let i in this.freeRects) {
             r = this.freeRects[i];
             if (r.width >= width && r.height >= height) {
-                areaFit = (this.options.logic === PACKING_LOGIC.MAX_AREA) ?
-                    r.width * r.height - width * height :
-                    Math.min(r.width - width, r.height - height);
+                if (this.options.logic === PACKING_LOGIC.MAX_AREA) {
+                    // the rect with the lowest rest area wins
+                    areaFit =  r.width * r.height - width * height;
+                } else if (this.options.logic === PACKING_LOGIC.FILL_WIDTH) {
+                    // this logic needs to factors to build a score. 
+                    // 1. rect position: choose the most rightest one with the lowest y coordinate.
+                    // 2. size that needs to grow to place the element. The lower the better score (leads to optimal rotation placement)
+
+                    const currentRectPositionScore = r.x + r.y * this.maxWidth; // each y value adds a full width to the score to balance x and y coordinates to a single number
+                    const numberOfBetterRects = this.freeRects.filter(rect =>  (rect.x + rect.y * this.maxWidth) < currentRectPositionScore).length; // search if there are rects, righter and a lower y coordinate.
+
+                    // calculate how much space will be add to total height
+                    const heightToGain = r.y + height - this.height;
+                    
+                    areaFit = numberOfBetterRects + heightToGain; // add both factors together 
+                } else {
+                    // the rect with the lowest loss of either width or height wins
+                    areaFit = Math.min(r.width - width, r.height - height);
+                }
                 if (areaFit < score) {
                     bestNode = new Rectangle(width, height, r.x, r.y);
                     score = areaFit;
@@ -203,9 +228,19 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
 
             // Continue to test 90-degree rotated rectangle
             if (r.width >= height && r.height >= width) {
-                areaFit = (this.options.logic === PACKING_LOGIC.MAX_AREA) ?
-                    r.width * r.height - height * width :
-                    Math.min(r.height - width, r.width - height);
+                if (this.options.logic === PACKING_LOGIC.MAX_AREA) {
+                    areaFit =  r.width * r.height - height * width;
+                } else if (this.options.logic === PACKING_LOGIC.FILL_WIDTH) {
+                    const currentRectPositionScore = r.x + r.y * this.maxWidth;
+                    const numberOfBetterRects = this.freeRects.filter(rect =>  (rect.x + rect.y * this.maxWidth) < currentRectPositionScore).length; // search if there are rects, righter and a lower y coordinate.
+
+                    // calculate how much space will be add to total height
+                    const heightToGain = r.y + width - this.height;
+                    
+                    areaFit = numberOfBetterRects + heightToGain; // add both factors together 
+                } else {
+                    areaFit = Math.min(r.height - width, r.width - height);
+                }
                 if (areaFit < score) {
                     bestNode = new Rectangle(height, width, r.x, r.y, true); // Rotated node
                     score = areaFit;
@@ -304,6 +339,9 @@ export class MaxRectsBin<T extends IRectangle = Rectangle> extends Bin<T> {
         if (this.options.pot) {
             tmpWidth = Math.pow(2, Math.ceil(Math.log(tmpWidth) * Math.LOG2E));
             tmpHeight = Math.pow(2, Math.ceil(Math.log(tmpHeight) * Math.LOG2E));
+        }
+        if (this.options.logic === PACKING_LOGIC.FILL_WIDTH) {
+            tmpWidth = this.maxWidth;
         }
         if (this.options.square) {
             tmpWidth = tmpHeight = Math.max(tmpWidth, tmpHeight);

--- a/src/maxrects-packer.ts
+++ b/src/maxrects-packer.ts
@@ -110,7 +110,7 @@ export class MaxRectsPacker<T extends IRectangle = Rectangle> {
         if (args.length === 1) {
             if (typeof args[0] !== 'object') throw new Error("MacrectsPacker.add(): Wrong parameters");
             const rect = args[0] as T;
-            if (rect.width > this.width || rect.height > this.height) {
+            if (!((rect.width <= this.width && rect.height <= this.height) || (this.options.allowRotation && rect.width <= this.height && rect.height <= this.width))) {
                 this.bins.push(new OversizedElementBin<T>(rect));
             } else {
                 let added = this.bins.slice(this._currentBinIndex).find(bin => bin.add(rect) !== undefined);
@@ -127,7 +127,7 @@ export class MaxRectsPacker<T extends IRectangle = Rectangle> {
             const rect: IRectangle = new Rectangle(args[0], args[1]);
             if (args.length > 2) rect.data = args[2];
 
-            if (rect.width > this.width || rect.height > this.height) {
+            if (!((rect.width <= this.width && rect.height <= this.height) || (this.options.allowRotation && rect.width <= this.height && rect.height <= this.width))) {
                 this.bins.push(new OversizedElementBin<T>(rect as T));
             } else {
                 let added = this.bins.slice(this._currentBinIndex).find(bin => bin.add(rect as T) !== undefined);

--- a/src/maxrects-packer.ts
+++ b/src/maxrects-packer.ts
@@ -6,9 +6,9 @@ import { Bin, IBin } from "./abstract-bin";
 export const EDGE_MAX_VALUE: number = 4096;
 export const EDGE_MIN_VALUE: number = 128;
 export enum PACKING_LOGIC {
-    MAX_AREA = "maxArea",
-    MAX_EDGE = "maxEdge",
-    FILL_WIDTH = "fillWidth",
+    MAX_AREA = 0,
+    MAX_EDGE = 1,
+    FILL_WIDTH = 2,
 }
 
 /**

--- a/src/maxrects-packer.ts
+++ b/src/maxrects-packer.ts
@@ -6,8 +6,9 @@ import { Bin, IBin } from "./abstract-bin";
 export const EDGE_MAX_VALUE: number = 4096;
 export const EDGE_MIN_VALUE: number = 128;
 export enum PACKING_LOGIC {
-    MAX_AREA = 0,
-    MAX_EDGE = 1
+    MAX_AREA = "maxArea",
+    MAX_EDGE = "maxEdge",
+    FILL_WIDTH = "fillWidth",
 }
 
 /**

--- a/test/maxrects-bin.spec.js
+++ b/test/maxrects-bin.spec.js
@@ -351,7 +351,7 @@ describe("border", () => {
 
 describe("logic FILL_WIDTH", () => {
     beforeEach(() => {
-        bin = new MaxRectsBin(1024, 512, 0, {allowRotation: true, logic: "fillWidth", pot: false, square: false});
+        bin = new MaxRectsBin(1024, 512, 0, {allowRotation: true, logic: 2, pot: false, square: false});
     });
 
     test("sets all elements along width with the smallest height", () => {

--- a/test/maxrects-bin.spec.js
+++ b/test/maxrects-bin.spec.js
@@ -348,3 +348,71 @@ describe("border", () => {
         }
     });
 });
+
+describe("logic FILL_WIDTH", () => {
+    beforeEach(() => {
+        bin = new MaxRectsBin(1024, 512, 0, {allowRotation: true, logic: "fillWidth", pot: false, square: false});
+    });
+
+    test("sets all elements along width with the smallest height", () => {
+        /**
+         * Visualize the placement result
+         * _______________________
+         * | ███  ███  ███      |  
+         * ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+         */
+        
+        let position1 = bin.add(300, 50, {});
+        let position2 = bin.add(50, 300, {});
+        let position3 = bin.add(300, 50, {});
+        expect(position1.x).toBe(0);
+        expect(position1.y).toBe(0);
+        expect(position2.x).toBe(300);
+        expect(position2.y).toBe(0);
+        expect(position3.x).toBe(600);
+        expect(position3.y).toBe(0);
+        expect(bin.width).toBe(1024);
+        expect(bin.height).toBe(50);
+    });
+
+    test("adds rects correctly with rotation", () => {
+        /**
+         * Visualize the placement result (1 vertical at the end)
+         * _______________________
+         * | ███  ███  ███  █ |
+         * | ███  ███  ███  █ |
+         * | ███  ███  ███  █ |
+         * | ██████                     |
+         * ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+         */
+        
+        const rects = [
+            [300, 100],
+            [100, 300],
+            [300, 100],
+            [300, 100],
+            [100, 300],
+            [300, 100],
+            [300, 100],
+            [100, 300],
+            [300, 100],
+            [300, 100],
+            [300, 100],
+            [100, 600],
+        ]
+        rects.forEach(rect => bin.add(rect[0], rect[1]));
+        expect([bin.rects[0].x, bin.rects[0].y]).toEqual([0, 0]);
+        expect([bin.rects[1].x, bin.rects[1].y]).toEqual([300, 0]);
+        expect([bin.rects[2].x, bin.rects[2].y]).toEqual([600, 0]);
+        expect([bin.rects[3].x, bin.rects[3].y]).toEqual([0, 100]);
+        expect([bin.rects[4].x, bin.rects[4].y]).toEqual([300, 100]);
+        expect([bin.rects[5].x, bin.rects[5].y]).toEqual([600, 100]);
+        expect([bin.rects[6].x, bin.rects[6].y]).toEqual([900, 0]);
+        expect([bin.rects[7].x, bin.rects[7].y]).toEqual([0, 200]);
+        expect([bin.rects[8].x, bin.rects[8].y]).toEqual([300, 200]);
+        expect([bin.rects[9].x, bin.rects[9].y]).toEqual([600, 200]);
+        expect([bin.rects[10].x, bin.rects[10].y]).toEqual([0, 300]);
+        expect(bin.height).toBe(400);
+    });
+
+});

--- a/test/maxrects-bin.spec.js
+++ b/test/maxrects-bin.spec.js
@@ -371,7 +371,7 @@ describe("logic FILL_WIDTH", () => {
         expect(position2.y).toBe(0);
         expect(position3.x).toBe(600);
         expect(position3.y).toBe(0);
-        expect(bin.width).toBe(1024);
+        expect(bin.width).toBe(900);
         expect(bin.height).toBe(50);
     });
 
@@ -407,11 +407,12 @@ describe("logic FILL_WIDTH", () => {
         expect([bin.rects[3].x, bin.rects[3].y]).toEqual([0, 100]);
         expect([bin.rects[4].x, bin.rects[4].y]).toEqual([300, 100]);
         expect([bin.rects[5].x, bin.rects[5].y]).toEqual([600, 100]);
-        expect([bin.rects[6].x, bin.rects[6].y]).toEqual([900, 0]);
-        expect([bin.rects[7].x, bin.rects[7].y]).toEqual([0, 200]);
-        expect([bin.rects[8].x, bin.rects[8].y]).toEqual([300, 200]);
-        expect([bin.rects[9].x, bin.rects[9].y]).toEqual([600, 200]);
+        expect([bin.rects[6].x, bin.rects[6].y]).toEqual([0, 200]);
+        expect([bin.rects[7].x, bin.rects[7].y]).toEqual([300, 200]);
+        expect([bin.rects[8].x, bin.rects[8].y]).toEqual([600, 200]);
+        expect([bin.rects[9].x, bin.rects[9].y]).toEqual([900, 0]);
         expect([bin.rects[10].x, bin.rects[10].y]).toEqual([0, 300]);
+        expect(bin.width).toBe(1000);
         expect(bin.height).toBe(400);
     });
 

--- a/test/maxrects-packer.spec.js
+++ b/test/maxrects-packer.spec.js
@@ -126,6 +126,23 @@ describe("#add", () => {
         expect(packer.bins[1].rects[0].width).toBe(2000);
         expect(packer.bins[1].rects[0].oversized).toBe(true);
     });
+
+    test("checks oversized elements rotation and adds rotated", () => {
+        const packer = new MaxRectsPacker(512, 1024, 0, {...opt, allowRotation: true});
+        packer.add(640, 256, {num: 1});
+        expect(packer.bins.length).toBe(1);
+        expect(packer.bins[0].rects[0].width).toBe(256);
+        expect(packer.bins[0].rects[0].height).toBe(640);
+        expect(packer.bins[0].rects[0].oversized).toBe(false);
+    });
+
+    test("checks oversized elements and skip rotation when set to false", () => {
+        const packer = new MaxRectsPacker(512, 1024, 0, {...opt, allowRotation: false});
+        packer.add(640, 256, {num: 1});
+        expect(packer.bins.length).toBe(1);
+        expect(packer.bins[0].rects[0].width).toBe(640);
+        expect(packer.bins[0].rects[0].oversized).toBe(true);
+    });
 });
 
 describe("#sort", () => {


### PR DESCRIPTION
Hi, here is my version on how it should work.
This PR tackles #51 
It currently allows only the width dimension.

What have i done:

- found a bug when oversized elements fits into bin but in rotated manner
- add tests to check the bug
- changed PACKING_LOGIC values to be strings instead of numbers to make the logic option more readable
- Added new logic option *fillWidth* because this feature is mainly related to the `findNode` method
- added logic in `findNode`for *fillWidth*
- added tests for logic *fillWidth*
- addes some comments helping me and hopefully others to explain what some code is doing
- updated Readme.md to explain logic option

hope everything is clear and seeing forward for some feedback :)